### PR TITLE
Fix team creation on arrow click

### DIFF
--- a/src/components/dashboard/EventTeam.vue
+++ b/src/components/dashboard/EventTeam.vue
@@ -36,7 +36,7 @@
             value=">"
             :class="$style.submit"
             :data-event-id="event.id"
-            @click="submitCreateTeam"
+            @mousedown="submitCreateTeam"
           >
             <i class="fas fa-arrow-circle-right"></i>
           </button>
@@ -69,7 +69,7 @@
             value=">"
             :class="$style.submit"
             :data-event-id="event.id"
-            @click="submitJoinTeam"
+            @mousedown="submitJoinTeam"
           >
             <i class="fas fa-arrow-circle-right"></i>
           </button>


### PR DESCRIPTION
Fixes #136.

An easy way out! :sweat_smile: 
Mousedown event is triggered before a blur event.