### PR TITLE
Fix: Google authentication with a new id does not redirect automatically

### DIFF
--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -280,15 +280,15 @@ export default {
           } else {
             this.$recaptcha("login")
               .then((recaptchaToken) => {
-                this._register(idToken, name, this.referral, recaptchaToken)
-                .then((_) => {
-                  this.loading = false;
-                  this.onRedirectAuth(true);
-                })
-                .catch((err) => {
-                  this.loading = false;
-                  this.$toasted.global.error_post({ message: err.message });
-                });
+                return this._register(idToken, name, this.referral, recaptchaToken);
+              })
+              .then((_) => {
+                this.loading = false;
+                this.onRedirectAuth(true);
+              })
+              .catch((err) => {
+                this.loading = false;
+                this.$toasted.global.error_post({ message: err.message });
               });
           }
         });

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -281,14 +281,14 @@ export default {
             this.$recaptcha("login")
               .then((recaptchaToken) => {
                 this._register(idToken, name, this.referral, recaptchaToken)
-              })
-              .then((_) => {
-                this.loading = false;
-                this.onRedirectAuth(true);
-              })
-              .catch((err) => {
-                this.loading = false;
-                this.$toasted.global.error_post({ message: err.message });
+                .then((_) => {
+                  this.loading = false;
+                  this.onRedirectAuth(true);
+                })
+                .catch((err) => {
+                  this.loading = false;
+                  this.$toasted.global.error_post({ message: err.message });
+                });
               });
           }
         });


### PR DESCRIPTION
**A possible reason for the bug**:

- The `onRedirectAuth(...)` function is called before `_register(...)` is executed completely.
- So, before the token is stored in the localStorage, the page gets navigated to `/profile/edit`.
- Due to the navigation guard, the URL changes to `/login?redirect=/profile/edit`, instead of directly going to `/profile/edit`.